### PR TITLE
Fix default AID explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ portal](https://developer.fidesmo.com/).
     echo 'fidesmoAppId: yourAppID' >> $HOME/.gradle/gradle.properties
     echo 'fidesmoAppKey: yourAppKey' >> $HOME/.gradle/gradle.properties
 
-The fidesmo plugin installs per default to the aid a00000061700<fidesmoAppKey>0101.
+The fidesmo plugin installs per default to the aid a00000061700[fidesmoAppID]0101.
 
 Example usage
 -------------


### PR DESCRIPTION
The default AID uses the AppID, not the AppKey as described.
Moreover, angle brackets do not show up in Github-flavored markdown so I've replaced them with square brackets.